### PR TITLE
Update calls to CQC API

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -118,9 +118,18 @@ var config = convict({
       },
     },
   },
-  cqcApiUrl: {
-    doc: 'The API endpoint for CQC',
-    default: 'https://api.cqc.org.uk/public/v1',
+  cqcApi: {
+    url: {
+      doc: 'The API endpoint for CQC',
+      format: 'url',
+      default: 'https://api.service.cqc.org.uk/public/v1',
+    },
+    subscriptionKey: {
+      doc: 'The subscription key passed in CQC API calls',
+      format: String,
+      default: '',
+      env: 'CQC_SUBSCRIPTION_KEY',
+    },
   },
   slack: {
     url: {

--- a/src/cqc_changes/changes.js
+++ b/src/cqc_changes/changes.js
@@ -4,7 +4,8 @@ const config = require('../../config/index')
 
 axiosRetry(axios, { retries: 3, retryDelay: axiosRetry.exponentialDelay });
 
-const cqcEndpoint = config.get('cqcApiUrl')
+const cqcEndpoint = config.get('cqcApi.url');
+const cqcSubscriptionKey = config.get('cqcApi.subscriptionKey');
 
 const getChangedIds = async (startTimestamp, endTimestamp) => {
     let changes = [];
@@ -13,7 +14,7 @@ const getChangedIds = async (startTimestamp, endTimestamp) => {
 
     do {
       const changeUrl = cqcEndpoint + nextPage;
-      const response = await axios.get(changeUrl);
+      const response = await axios.get(changeUrl, { 'headers': { 'Ocp-Apim-Subscription-Key': cqcSubscriptionKey }});
       nextPage = response.data.nextPageUri;
             
       response.data.changes.forEach((location) => {

--- a/src/cqc_changes/update.js
+++ b/src/cqc_changes/update.js
@@ -7,7 +7,8 @@ const slack = require('../utils/slack/slack-logger');
 
 axiosRetry(axios, { retries: 3, retryDelay: axiosRetry.exponentialDelay });
 
-const cqcEndpoint = config.get('cqcApiUrl')
+const cqcEndpoint = config.get('cqcApi.url');
+const cqcSubscriptionKey = config.get('cqcApi.subscriptionKey');
 
 const updateLocation = async (location, runCount, rateLimitExceededLocations, retrying) => {
     try {
@@ -15,7 +16,7 @@ const updateLocation = async (location, runCount, rateLimitExceededLocations, re
         console.log(`Updated ${runCount} locations`);
       }
 
-      const individualLocation = await axios.get(cqcEndpoint + '/locations/' + location.locationId);
+      const individualLocation = await axios.get(cqcEndpoint + '/locations/' + location.locationId, { 'headers': { 'Ocp-Apim-Subscription-Key': cqcSubscriptionKey }});
 
       if (!individualLocation.data.deregistrationDate) {
         // not deregistered so must exist


### PR DESCRIPTION
- The CQC API endpoint has been changed and we now also have to pass a subscription key which they use to identify our service
- This PR updates the endpoint and adds the key as a header to CQC API calls