### PR TITLE
Fix - ERR_FS_FILE_TOO_LARGE when uploading analysis files

### DIFF
--- a/jobs/generate_analysis_files.js
+++ b/jobs/generate_analysis_files.js
@@ -62,13 +62,13 @@ const zipAndUploadReports = async () => {
 
   await exec(`cd ${reportDir} && zip -r ${zipName} *.csv`);
 
-  return uploadFile(zipName, fs.readFileSync(`${reportDir}/${zipName}`));
+  return uploadFile(zipName, fs.createReadStream(`${reportDir}/${zipName}`));
 };
 
 const uploadReportsToDataEngineering = async (workplaceFilePath, workerFilePath, leaverFilePath) => {
-  await uploadFileToDataEngineering(getFileKey('workplace'), fs.readFileSync(workplaceFilePath));
-  await uploadFileToDataEngineering(getFileKey('worker'), fs.readFileSync(workerFilePath));
-  await uploadFileToDataEngineering(getFileKey('leaver'), fs.readFileSync(leaverFilePath));
+  await uploadFileToDataEngineering(getFileKey('workplace'), fs.createReadStream(workplaceFilePath));
+  await uploadFileToDataEngineering(getFileKey('worker'), fs.createReadStream(workerFilePath));
+  await uploadFileToDataEngineering(getFileKey('leaver'), fs.createReadStream(leaverFilePath));
 };
 
 const getFileKey = (fileType) => {


### PR DESCRIPTION
#### Work done
- replace `fs.readFileSync` call with `fs.createReadStream` to allow uploading files over 2GB in size

(tested on preprod that we can upload a file over 2GB to S3 if we load it with `fs.createReadStream`)

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
