### PR TITLE
Feature branch/1647 1655 remove 2 questions from analysis files and fix file too large error

### DIFF
--- a/jobs/generate_analysis_files.js
+++ b/jobs/generate_analysis_files.js
@@ -62,13 +62,13 @@ const zipAndUploadReports = async () => {
 
   await exec(`cd ${reportDir} && zip -r ${zipName} *.csv`);
 
-  return uploadFile(zipName, fs.readFileSync(`${reportDir}/${zipName}`));
+  return uploadFile(zipName, fs.createReadStream(`${reportDir}/${zipName}`));
 };
 
 const uploadReportsToDataEngineering = async (workplaceFilePath, workerFilePath, leaverFilePath) => {
-  await uploadFileToDataEngineering(getFileKey('workplace'), fs.readFileSync(workplaceFilePath));
-  await uploadFileToDataEngineering(getFileKey('worker'), fs.readFileSync(workerFilePath));
-  await uploadFileToDataEngineering(getFileKey('leaver'), fs.readFileSync(leaverFilePath));
+  await uploadFileToDataEngineering(getFileKey('workplace'), fs.createReadStream(workplaceFilePath));
+  await uploadFileToDataEngineering(getFileKey('worker'), fs.createReadStream(workerFilePath));
+  await uploadFileToDataEngineering(getFileKey('leaver'), fs.createReadStream(leaverFilePath));
 };
 
 const getFileKey = (fileType) => {

--- a/src/generate_analysis_files/reports/workplace/batch.js
+++ b/src/generate_analysis_files/reports/workplace/batch.js
@@ -1212,27 +1212,6 @@ const findWorkplacesByBatch = (batchNum) =>
 		END benchmarkscount_year,
 
       CASE  
-        WHEN  "MoneySpentOnAdvertisingInTheLastFourWeeks" ='Don''t know'
-          THEN '-1' 
-        WHEN  "MoneySpentOnAdvertisingInTheLastFourWeeks"= 'None'
-          THEN '0'
-         ELSE(
-              SELECT  "MoneySpentOnAdvertisingInTheLastFourWeeks" FROM cqc."Establishment"  WHERE     "EstablishmentID" = e."EstablishmentID"           
-             )
-        END Advertising_costs,
-
-     CASE  
-       WHEN  "PeopleInterviewedInTheLastFourWeeks" ='Don''t know'
-          THEN '-1'
-        WHEN  "PeopleInterviewedInTheLastFourWeeks"= 'None'
-          THEN '0'
-      
-         ELSE(
-              SELECT "PeopleInterviewedInTheLastFourWeeks" FROM cqc."Establishment" WHERE "EstablishmentID" =  e."EstablishmentID"       
-             )
-        END Number_interviewed,
-
-      CASE  
         WHEN  "DoNewStartersRepeatMandatoryTrainingFromPreviousEmployment" = 'Yes, always'
            THEN 1
         WHEN  "DoNewStartersRepeatMandatoryTrainingFromPreviousEmployment"= 'Yes, very often'


### PR DESCRIPTION
#### Work done
- replace `fs.readFileSync` call with `fs.createReadStream` to allow uploading files over 2GB in size
- Removed the following questions from query for workplace batch job
  - How much money have you spent on advertising for staff in the last 4 weeks?
  - How many people have you interviewed for care worker roles in the last 4 weeks?

#### Tests
Does this PR include tests for the changes introduced?
- [ ] Yes
- [ ] No, I found it difficult to test
- [x] No, they are not required for this change
