### PR TITLE
change the file name to benchmark

### DIFF
--- a/config/benchmark.yaml
+++ b/config/benchmark.yaml
@@ -2,4 +2,4 @@ aws:
   region: eu-west-1
   secrets:
     use: false
-    wallet: benchmarks/api
+    wallet: benchmark/api

--- a/config/benchmark.yaml
+++ b/config/benchmark.yaml
@@ -2,4 +2,4 @@ aws:
   region: eu-west-1
   secrets:
     use: false
-    wallet: benchmark/api
+    wallet: benchmarks/api


### PR DESCRIPTION
Change the benchmarks to the benchmark to keep it consistent with AWS 