### PR TITLE
Fix/cqc location

### DIFF
--- a/src/cqc_changes/complete.js
+++ b/src/cqc_changes/complete.js
@@ -10,14 +10,12 @@ const updateComplete = async (locations, startDate, endDate) => {
     const endDateToDate = new Date(endDate);
     const finishDate = new Date();
 
-
     const failedLocations = locations.filter((location) => {
       return location.status != 'success'
     });
     const failed = failedLocations.length ? true : false;
   
     if (failed) {
-
       console.log(`${failedLocations.length} updates failed`);
       await slack.error(
         `${config.get('db.name')} - CQC changes`, 

--- a/src/cqc_changes/complete.js
+++ b/src/cqc_changes/complete.js
@@ -10,13 +10,6 @@ const updateComplete = async (locations, startDate, endDate) => {
     const endDateToDate = new Date(endDate);
     const finishDate = new Date();
 
-    locations
-  .filter(location => location.status !== 'success')
-  .forEach(location => {
-    console.log(
-      `Failed location: ${location.locationId}, status: ${location.status}`
-    );
-  });
 
     const failedLocations = locations.filter((location) => {
       return location.status != 'success'
@@ -24,12 +17,7 @@ const updateComplete = async (locations, startDate, endDate) => {
     const failed = failedLocations.length ? true : false;
   
     if (failed) {
-      console.log(
-  failedLocations.map(x => ({
-    locationId: x.locationId,
-    status: x.status
-  }))
-);
+
       console.log(`${failedLocations.length} updates failed`);
       await slack.error(
         `${config.get('db.name')} - CQC changes`, 

--- a/src/cqc_changes/complete.js
+++ b/src/cqc_changes/complete.js
@@ -10,12 +10,26 @@ const updateComplete = async (locations, startDate, endDate) => {
     const endDateToDate = new Date(endDate);
     const finishDate = new Date();
 
+    locations
+  .filter(location => location.status !== 'success')
+  .forEach(location => {
+    console.log(
+      `Failed location: ${location.locationId}, status: ${location.status}`
+    );
+  });
+
     const failedLocations = locations.filter((location) => {
       return location.status != 'success'
     });
     const failed = failedLocations.length ? true : false;
   
     if (failed) {
+      console.log(
+  failedLocations.map(x => ({
+    locationId: x.locationId,
+    status: x.status
+  }))
+);
       console.log(`${failedLocations.length} updates failed`);
       await slack.error(
         `${config.get('db.name')} - CQC changes`, 

--- a/src/cqc_changes/update.js
+++ b/src/cqc_changes/update.js
@@ -31,6 +31,10 @@ const updateLocation = async (location, runCount, rateLimitExceededLocations, re
     } catch (error) {
 
         console.log('Failed location:', location.locationId);
+        console.log(
+  'Failed location object:',
+  JSON.stringify(location, null, 2)
+);
   console.log('Status:', error.response?.status);
   console.log('Response:', error.response?.data);
   
@@ -47,7 +51,24 @@ const updateLocation = async (location, runCount, rateLimitExceededLocations, re
 
   console.log(`Marked ${location.locationId} success`);
 
-} else if (error.response?.status === 429) {
+}else if (
+    error.response?.status === 400 &&
+    error.response?.data?.message === 'Bad request'
+  ) {
+    console.log(
+      `Unknown location format: ${location.locationId}`
+    );
+
+    await slack.info(
+      `${config.get('db.name')} - CQC changes`,
+      `Unknown location format encountered: ${location.locationId}`
+    );
+
+    updateStatus(location, 'success');
+
+  } 
+
+else if (error.response?.status === 429) {
         console.log('Adding location to rateLimitExceededLocations array');
         rateLimitExceededLocations.push(location);
       } else {

--- a/src/cqc_changes/update.js
+++ b/src/cqc_changes/update.js
@@ -27,8 +27,10 @@ const updateLocation = async (location, runCount, rateLimitExceededLocations, re
       
       updateStatus(location, 'success');
     } catch (error) {
-  
-if (
+      if (error.response.data.message && error.response.data.message.indexOf('No Locations found') > -1) {
+        await models.location.deleteLocation(location.locationId);
+        updateStatus(location, 'success');
+      } else if (
     error.response?.status === 400 &&
     error.response?.data?.message === 'Bad request'
   ) {
@@ -43,9 +45,8 @@ if (
 
     updateStatus(location, 'success');
 
-  } 
-
-else if (error.response?.status === 429) {
+  }
+     else if (error.response?.status === 429) {
         console.log('Adding location to rateLimitExceededLocations array');
         rateLimitExceededLocations.push(location);
       } else {

--- a/src/cqc_changes/update.js
+++ b/src/cqc_changes/update.js
@@ -16,6 +16,8 @@ const updateLocation = async (location, runCount, rateLimitExceededLocations, re
         console.log(`Updated ${runCount} locations`);
       }
 
+      console.log(`Fetching location ${location.locationId}`);
+
       const individualLocation = await axios.get(cqcEndpoint + '/locations/' + location.locationId, { 'headers': { 'Ocp-Apim-Subscription-Key': cqcSubscriptionKey }});
 
       if (!individualLocation.data.deregistrationDate) {
@@ -27,6 +29,11 @@ const updateLocation = async (location, runCount, rateLimitExceededLocations, re
       
       updateStatus(location, 'success');
     } catch (error) {
+
+        console.log('Failed location:', location.locationId);
+  console.log('Status:', error.response?.status);
+  console.log('Response:', error.response?.data);
+  
       if (error.response.data.message && error.response.data.message.indexOf('No Locations found') > -1) {
         await models.location.deleteLocation(location.locationId);
         updateStatus(location, 'success');

--- a/src/cqc_changes/update.js
+++ b/src/cqc_changes/update.js
@@ -16,8 +16,6 @@ const updateLocation = async (location, runCount, rateLimitExceededLocations, re
         console.log(`Updated ${runCount} locations`);
       }
 
-      console.log(`Fetching location ${location.locationId}`);
-
       const individualLocation = await axios.get(cqcEndpoint + '/locations/' + location.locationId, { 'headers': { 'Ocp-Apim-Subscription-Key': cqcSubscriptionKey }});
 
       if (!individualLocation.data.deregistrationDate) {
@@ -29,29 +27,8 @@ const updateLocation = async (location, runCount, rateLimitExceededLocations, re
       
       updateStatus(location, 'success');
     } catch (error) {
-
-        console.log('Failed location:', location.locationId);
-        console.log(
-  'Failed location object:',
-  JSON.stringify(location, null, 2)
-);
-  console.log('Status:', error.response?.status);
-  console.log('Response:', error.response?.data);
   
-     if (
-  error.response?.data?.message?.includes('No Locations found')
-) {
-  console.log(`Deleting ${location.locationId}`);
-
-  await models.location.deleteLocation(location.locationId);
-
-  console.log(`Deleted ${location.locationId}`);
-
-  updateStatus(location, 'success');
-
-  console.log(`Marked ${location.locationId} success`);
-
-}else if (
+if (
     error.response?.status === 400 &&
     error.response?.data?.message === 'Bad request'
   ) {

--- a/src/cqc_changes/update.js
+++ b/src/cqc_changes/update.js
@@ -34,10 +34,20 @@ const updateLocation = async (location, runCount, rateLimitExceededLocations, re
   console.log('Status:', error.response?.status);
   console.log('Response:', error.response?.data);
   
-      if (error.response.data.message && error.response.data.message.indexOf('No Locations found') > -1) {
-        await models.location.deleteLocation(location.locationId);
-        updateStatus(location, 'success');
-      } else if (error.response.status === 429) {
+     if (
+  error.response?.data?.message?.includes('No Locations found')
+) {
+  console.log(`Deleting ${location.locationId}`);
+
+  await models.location.deleteLocation(location.locationId);
+
+  console.log(`Deleted ${location.locationId}`);
+
+  updateStatus(location, 'success');
+
+  console.log(`Marked ${location.locationId} success`);
+
+} else if (error.response?.status === 429) {
         console.log('Adding location to rateLimitExceededLocations array');
         rateLimitExceededLocations.push(location);
       } else {


### PR DESCRIPTION
## Summary

The `cqc-changes-log` channel was receiving `Error: Request failed with status code 400` notifications from the CQC changes job.

Investigation showed that these errors were caused by location IDs in a format we do not use within Adult Social Care (for example, `rx1cc`). These IDs are returned by the CQC changes feed, but requests to the CQC location endpoint for these IDs return a `400 Bad Request` response.

Previously, this scenario was not handled, causing the job to report a failed update.

This change adds explicit handling for these responses. The location is not deleted, as we have not yet decided how these IDs should be treated. Instead, the job records the occurrence, sends a notification, and continues processing successfully.

This ensures that:

* The scheduled job completes without reporting a failure.
* We remain aware of any unsupported location IDs returned by the CQC API.
* The records are retained until a decision is made on how they should be handled.
